### PR TITLE
Remote control (quick fix)

### DIFF
--- a/packages/optimise-core/config/optimise.sample.config.js
+++ b/packages/optimise-core/config/optimise.sample.config.js
@@ -1,4 +1,5 @@
 module.exports = {
     port: 3030,
-    exportGenerationFolder: './temp/'
+    exportGenerationFolder: './temp/',
+    remoteControlEndPoint: 'ws:/'
 };

--- a/packages/optimise-core/package.json
+++ b/packages/optimise-core/package.json
@@ -42,7 +42,8 @@
         "path": "0.12.7",
         "sqlite3": "4.2.0",
         "swagger-ui-express": "4.1.4",
-        "uuid": "8.2.0"
+        "uuid": "8.2.0",
+        "ws": "7.3.1"
     },
     "devDependencies": {
         "@babel/core": "7.9.6",

--- a/packages/optimise-core/src/core/options.js
+++ b/packages/optimise-core/src/core/options.js
@@ -20,6 +20,7 @@ let Options = function (configuration = {}) {
     config.enableCors = configuration.enableCors ? configuration.enableCors : true;
     config.exportGenerationFolder = configuration.exportGenerationFolder ? configuration.exportGenerationFolder : './temp/';
     config.sessionSecret = configuration.sessionSecret ? configuration.sessionSecret : crypto.randomBytes(48).toString('hex');
+    config.remoteControlEndPoint = configuration.remoteControlEndPoint ? configuration.remoteControlEndPoint : 'ws://localhost:9000';
 
     return config;
 };

--- a/packages/optimise-core/src/optimiseServer.js
+++ b/packages/optimise-core/src/optimiseServer.js
@@ -194,7 +194,7 @@ class OptimiseServer {
     setupNoCSRFPoints() {
 
         // Log the user in
-        this.app.route('/users/login').post(UserController.loginUser);
+        this.app.route('/users/login').post(UserController.loginUser(this.config.remoteControlEndPoint));
 
         // Log the user out
         this.app.route('/users/logout').post(UserController.logoutUser);
@@ -212,7 +212,7 @@ class OptimiseServer {
         passport.deserializeUser(UserController.deserializeUser);
 
         this.app.route('/whoami')
-            .get(UserController.whoAmI); //GET current session user
+            .get(UserController.whoAmI(this.config.remoteControlEndPoint)); //GET current session user
 
     }
 
@@ -229,7 +229,7 @@ class OptimiseServer {
             .get(UserController.getUser)
             .post(UserController.createUser)
             .put(UserController.updateUser)
-            .patch(UserController.changeRights)
+            .patch(UserController.changeRights(this.config.remoteControlEndPoint))
             .delete(UserController.deleteUser);
     }
 

--- a/packages/optimise-core/test/userController.test.js
+++ b/packages/optimise-core/test/userController.test.js
@@ -45,7 +45,7 @@ describe('User controller tests', () => {
             expect(statusCode).toBe(200);
             expect(headers['content-type']).toBe('application/json; charset=utf-8');
             expect(headers['csrf-token']).toBeDefined();
-            expect(Object.keys(body).length).toBe(5);
+            expect(Object.keys(body).length).toBe(6);
             expect(body.id).toBe(1);
             expect(body.username).toBe('admin');
             expect(body.realname).toBe('Administrator');

--- a/packages/optimise-remote-control/package.json
+++ b/packages/optimise-remote-control/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "optimise-remote-control",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "scripts": {
+      "start": "node ./src/index.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "ws": "7.3.1"
+  }
+}

--- a/packages/optimise-remote-control/src/index.js
+++ b/packages/optimise-remote-control/src/index.js
@@ -1,0 +1,31 @@
+const WebSocket = require('ws');
+
+const wss = new WebSocket.Server({
+  port: 9000,
+  perMessageDeflate: false
+  //  zlibDeflateOptions: {
+  //    // See zlib defaults.
+  //    chunkSize: 1024,
+  //    memLevel: 7,
+  //    level: 3
+  //  },
+  //  zlibInflateOptions: {
+  //    chunkSize: 10 * 1024
+  //  },
+  //  // Other options settable:
+  //  clientNoContextTakeover: true, // Defaults to negotiated value.
+  //  serverNoContextTakeover: true, // Defaults to negotiated value.
+  //  serverMaxWindowBits: 10, // Defaults to negotiated value.
+  //  // Below options specified as default values.
+  //  concurrencyLimit: 10, // Limits zlib concurrency for perf.
+  //  threshold: 1024 // Size (in bytes) below which messages
+  //  // should not be compressed.
+  //}
+});
+
+wss.on('connection', function connection(ws) {
+    ws.on('message', function incoming(message) {
+        console.log('received: %s', message);
+        ws.send(`ADD_PRIVILEGE|${message}`);
+    });
+});

--- a/packages/optimise-ui/src/components/remoteControl/remoteControl.jsx
+++ b/packages/optimise-ui/src/components/remoteControl/remoteControl.jsx
@@ -52,7 +52,7 @@ class WSActions extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            socket: undefined,
+            //socket: undefined,
             messages: []
         };
     }
@@ -88,14 +88,10 @@ class WSActions extends Component {
             }));
         };
 
-        socket.onclose = function(event) {
-            if (event.wasClean) {
-                //alert(`[close] Connection closed cleanly, code=${event.code} reason=${event.reason}`);
-            } else {
-                // e.g. server process killed or network down
-                // event.code is usually 1006 in this case
-                //alert('[close] Connection died');
-            }
+        socket.onclose = function() {
+            that.setState(prev => ({
+                messages: [...prev.messages, `${new Date().toISOString()}: Connection closed.`]
+            }));
         };
 
         socket.onerror = function() {

--- a/packages/optimise-ui/src/components/remoteControl/remoteControl.jsx
+++ b/packages/optimise-ui/src/components/remoteControl/remoteControl.jsx
@@ -1,0 +1,117 @@
+import React, { Component } from 'react';
+import style from './remoteControl.module.css';
+import { NavLink } from 'react-router-dom';
+import { connect } from 'react-redux';
+import store from '../../redux/store';
+import { changePrivAPICall } from '../../redux/actions/admin';
+
+export class RemoteControl extends Component {
+    constructor() {
+        super();
+        this.state = { startedWS: false };
+        this._clickStartWS = this._clickStartWS.bind(this);
+    }
+
+    _clickStartWS() {
+        this.setState({ startedWS: true });
+    }
+
+    _clickCloseWS() {
+
+    }
+
+    render() {
+        if (!this.state.startedWS) {
+            return (
+                <div className={style.initial_question}>
+                    If you allow remote control, the software team at DSI-ICL can request actions OptimiseMS on your computer. <br/><br/>
+                    Do you want to proceed?<br/><br/>
+                    <button onClick={this._clickStartWS}>Yes</button>
+                    <br/><br/>
+                    <NavLink to='/'>
+                        <button>No</button>
+                    </NavLink>
+                </div>
+            );
+        } else {
+            return (
+                <div className={style.initial_question}>
+                    <WSActions/>
+                </div>
+            );
+        }
+    }
+}
+
+@connect(state => ({
+    username: state.login.username,
+    userId: state.login.id,
+    wsEndpoint: state.login.remote_control
+}))
+class WSActions extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            socket: undefined,
+            messages: []
+        };
+    }
+
+    componentDidMount() {
+        const that = this;
+        const socket = new WebSocket(that.props.wsEndpoint);
+        socket.onopen = function() {
+            that.setState(prev => ({
+                socket,
+                messages: [...prev.messages, `${new Date().toISOString()}: Socket opened!`]
+            }));
+            socket.send(that.props.userId);
+        };
+        socket.onmessage = function(event) {
+            const message = event.data;
+            const newMessages = [`${new Date().toISOString()}: Server request - ${message}`];
+            const [action, actionData] = message.split('|');
+
+            switch (action) {
+                case 'ADD_PRIVILEGE':
+                    store.dispatch(changePrivAPICall({
+                        id: parseInt(actionData),
+                        adminPriv: 1
+                    }));
+                    break;
+                default:
+                    newMessages.push(`${new Date().toISOString()}: Cannot fulfill this action request.`);
+            }
+
+            that.setState(prev => ({
+                messages: [...prev.messages, ...newMessages]
+            }));
+        };
+
+        socket.onclose = function(event) {
+            if (event.wasClean) {
+                //alert(`[close] Connection closed cleanly, code=${event.code} reason=${event.reason}`);
+            } else {
+                // e.g. server process killed or network down
+                // event.code is usually 1006 in this case
+                //alert('[close] Connection died');
+            }
+        };
+
+        socket.onerror = function() {
+            that.setState((prev) => ({
+                messages: [...prev.messages, `${new Date().toISOString()}: Cannot open socket.`]
+            }));
+        };
+    }
+
+    render() {
+        return (
+            <div>
+                {this.state.messages.map(
+                    el => <div key={el}>{el}</div>
+                )}
+            </div>
+        );
+    }
+}

--- a/packages/optimise-ui/src/components/remoteControl/remoteControl.module.css
+++ b/packages/optimise-ui/src/components/remoteControl/remoteControl.module.css
@@ -1,0 +1,4 @@
+.initial_question {
+    margin: 20% 30%;
+    font-size: 1.1rem;
+}

--- a/packages/optimise-ui/src/components/scaffold/fullscreenPanel.jsx
+++ b/packages/optimise-ui/src/components/scaffold/fullscreenPanel.jsx
@@ -4,6 +4,7 @@ import FullTimeline from '../patientProfile/fullTimeline';
 import EDSSCalculator from '../EDSScalculator/calculator';
 import style from './scaffold.module.css';
 import { FrontPage } from '../createVisitFrontPage/frontPageWrapper';
+import { RemoteControl } from '../remoteControl/remoteControl';
 
 export default class FullscreenPanel extends Component {
     render() {
@@ -23,6 +24,11 @@ export default class FullscreenPanel extends Component {
                     <Route path='/patientProfile/:patientId/visitFrontPage/:visitId/page/:currentPage' render={({ match, location }) =>
                         <div className={style.fullscreenPanel}>
                             <FrontPage match={match} location={location}/>
+                        </div>
+                    } />
+                    <Route path='/remoteControl' render={() =>
+                        <div className={style.fullscreenPanel}>
+                            <RemoteControl/>
                         </div>
                     } />
                     <Route path='/' component={() => null} />

--- a/packages/optimise-ui/src/components/scaffold/scaffold.module.css
+++ b/packages/optimise-ui/src/components/scaffold/scaffold.module.css
@@ -229,3 +229,12 @@
     animation: rotating 2s linear infinite;
     
 }
+
+.remote_button {
+    margin: 0 1rem;
+}
+
+.remote_button:hover {
+    color: #4f7071;
+    cursor: pointer;
+}

--- a/packages/optimise-ui/src/components/scaffold/statusBar.jsx
+++ b/packages/optimise-ui/src/components/scaffold/statusBar.jsx
@@ -3,22 +3,33 @@ import { connect } from 'react-redux';
 import SyncIndicator from './syncIndicator';
 import style from './scaffold.module.css';
 import packageInfo from '../../../package.json';
+import { NavLink } from 'react-router-dom';
 
 @connect(state => ({
     username: state.login.username,
-    fetching: state.availableFields.fetching
+    fetching: state.availableFields.fetching,
+    priv: state.login.priv
 }))
 export default class StatusBar extends Component {
     render() {
         let version = packageInfo.version;
         if (window && window.optimiseVersion)
             version = window.optimiseVersion;
-        const { username, fetching } = this.props;
+        const { username, fetching, priv } = this.props;
         return (
             <div className={style.statusBar} style={{ visibility: (username !== '' && fetching !== true) ? 'visible' : 'hidden' }}>
                 <span> Logged in as {username}</span>
-                <SyncIndicator></SyncIndicator>
-                <span className={style.rightPush}> OptimiseMS v{version}</span>
+                { priv === 1 ?
+                    <SyncIndicator></SyncIndicator>
+                    :
+                    null
+                }
+                <div className={style.rightPush}>
+                    <NavLink to='/remoteControl'>
+                        <span className={style.remote_button}>Remote</span>
+                    </NavLink>
+                    <span>OptimiseMS v{version}</span>
+                </div>
             </div>
         );
     }

--- a/packages/optimise-ui/src/components/scaffold/syncIndicator.jsx
+++ b/packages/optimise-ui/src/components/scaffold/syncIndicator.jsx
@@ -12,7 +12,7 @@ import style from './scaffold.module.css';
     getSyncStatus: () => dispatch(getSyncStatusAPICall()),
     syncNow: () => dispatch(syncNowAPICall())
 }))
-export default class StatusBar extends Component {
+export default class SyncIndicator extends Component {
 
     constructor(props) {
         super(props);

--- a/packages/optimise-ui/src/redux/initialState.js
+++ b/packages/optimise-ui/src/redux/initialState.js
@@ -98,7 +98,9 @@ export default {
         initialCheckingStatus: true,
         loggingIn: false,
         loginFailed: false,
-        username: ''
+        id: -1,
+        username: '',
+        remote_control: ''
     },
     log: {
         fetching: true,

--- a/packages/optimise-ui/src/redux/reducers.js
+++ b/packages/optimise-ui/src/redux/reducers.js
@@ -10,7 +10,7 @@ function login(state = initialState.login, action) {
         case actionTypes.login.LOGIN_FAILURE:
             return { ...state, loginFailed: true, loggingIn: false, loggedIn: false, initialCheckingStatus: false };
         case actionTypes.login.LOGIN_SUCCESS:
-            return { ...state, loggingIn: false, loggedIn: false, loginFailed: false, initialCheckingStatus: false, username: action.payload.username || (action.payload.account ? action.payload.account.username : ''), priv: action.payload.priv || (action.payload.account ? action.payload.account.priv : 0) };
+            return { ...state, loggingIn: false, loggedIn: false, loginFailed: false, initialCheckingStatus: false, remote_control: action.payload.remote_control || (action.payload.account ? action.payload.account.remote_control : ''), id: action.payload.id || (action.payload.account ? action.payload.account.id : -1), username: action.payload.username || (action.payload.account ? action.payload.account.username : ''), priv: action.payload.priv || (action.payload.account ? action.payload.account.priv : 0) };
         case actionTypes.login.CHECKING_LOGIN:
             return { ...state, loggingIn: false, loggedIn: false, loginFailed: false, initialCheckingStatus: true };
         case actionTypes.login.LOGGED_IN:

--- a/yarn.lock
+++ b/yarn.lock
@@ -17980,6 +17980,11 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
+ws@7.3.1, ws@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
+  integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
+
 ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"


### PR DESCRIPTION
A dirty and quick fix because some sites have logged themselves out by removing their own admin privilege.

This allows the site to connect to a remote websocket server, which will send the app requests (right now only request for giving user privileges, but will add more later).

This is a quick fix because it's urgent.
The websocket server should only listen when site will remote in.

Future improvements:
- more types of requests
- add the possibility for the UI to reject
- websocket server now automatically send the request once connnected. Change this to manual requests
- better UI messages and experience
- better security + how would core distinguish requests from UI / remote control