### PR TITLE
fix: express rate limit is not a constrctor

### DIFF
--- a/packages/optimise-docker/launcher.js
+++ b/packages/optimise-docker/launcher.js
@@ -18,7 +18,7 @@ optimise.start().then(router => {
     // Binding static resources folder
     root.use('/static', express.static(path.normalize(`${__dirname}/static`)));
 
-    root.use(new rateLimit({
+    root.use(rateLimit({
         windowMs: 1 * 60 * 1000,
         max: 500
     }));


### PR DESCRIPTION
fix "rateLimit is not a constructor" for express-rate-limit@6.1.0