### PR TITLE
fix: rollback to webpack 4

### DIFF
--- a/packages/optimise-core/package.json
+++ b/packages/optimise-core/package.json
@@ -69,7 +69,7 @@
         "start-server-webpack-plugin": "2.2.5",
         "string-replace-loader": "3.1.0",
         "supertest": "6.2.2",
-        "webpack": "5.66.0",
+        "webpack": "4.44.2",
         "webpack-cli": "4.9.1",
         "webpack-node-externals": "3.0.0"
     },

--- a/packages/optimise-core/package.json
+++ b/packages/optimise-core/package.json
@@ -69,7 +69,7 @@
         "start-server-webpack-plugin": "2.2.5",
         "string-replace-loader": "3.1.0",
         "supertest": "6.2.2",
-        "webpack": "4.44.2",
+        "webpack": "4.46.0",
         "webpack-cli": "4.9.1",
         "webpack-node-externals": "3.0.0"
     },

--- a/packages/optimise-electron/package.json
+++ b/packages/optimise-electron/package.json
@@ -129,7 +129,7 @@
         "electron-builder": "22.14.5",
         "electron-reload": "1.5.0",
         "html-webpack-plugin": "5.5.0",
-        "webpack": "5.66.0",
+        "webpack": "4.44.2",
         "webpack-cli": "4.9.1",
         "webpack-merge": "5.8.0"
     }

--- a/packages/optimise-electron/package.json
+++ b/packages/optimise-electron/package.json
@@ -129,7 +129,7 @@
         "electron-builder": "22.14.5",
         "electron-reload": "1.5.0",
         "html-webpack-plugin": "5.5.0",
-        "webpack": "4.44.2",
+        "webpack": "4.46.0",
         "webpack-cli": "4.9.1",
         "webpack-merge": "5.8.0"
     }

--- a/packages/optimise-sync/package.json
+++ b/packages/optimise-sync/package.json
@@ -45,7 +45,7 @@
         "jest": "26.6.3",
         "rimraf": "3.0.2",
         "start-server-webpack-plugin": "2.2.5",
-        "webpack": "5.66.0",
+        "webpack": "4.44.2",
         "webpack-cli": "4.9.1"
     },
     "optionalDependencies": {

--- a/packages/optimise-sync/package.json
+++ b/packages/optimise-sync/package.json
@@ -45,7 +45,7 @@
         "jest": "26.6.3",
         "rimraf": "3.0.2",
         "start-server-webpack-plugin": "2.2.5",
-        "webpack": "4.44.2",
+        "webpack": "4.46.0",
         "webpack-cli": "4.9.1"
     },
     "optionalDependencies": {

--- a/packages/optimise-ui/package.json
+++ b/packages/optimise-ui/package.json
@@ -65,7 +65,7 @@
         "prop-types": "15.8.1",
         "react-app-rewired": "2.1.11",
         "react-scripts": "3.4.4",
-        "webpack": "5.66.0"
+        "webpack": "4.44.2"
     },
     "eslintConfig": {
         "extends": "react-app"

--- a/packages/optimise-ui/package.json
+++ b/packages/optimise-ui/package.json
@@ -65,7 +65,7 @@
         "prop-types": "15.8.1",
         "react-app-rewired": "2.1.11",
         "react-scripts": "3.4.4",
-        "webpack": "4.44.2"
+        "webpack": "4.46.0"
     },
     "eslintConfig": {
         "extends": "react-app"


### PR DESCRIPTION
Rollback to Webpack 4 since "start-server-webpack-plugin" is not supported for Webpack 5