### PR TITLE
Chore/maintainence dependency by merge react medium image zoom 5.x

### DIFF
--- a/packages/optimise-ui/package.json
+++ b/packages/optimise-ui/package.json
@@ -34,7 +34,7 @@
         "react-event-timeline": "1.6.3",
         "react-helmet-async": "1.3.0",
         "react-markdown": "8.0.3",
-        "react-medium-image-zoom": "5.0.2",
+        "react-medium-image-zoom": "3.1.3",
         "react-redux": "8.0.2",
         "react-router-dom": "5.3.3",
         "react-virtualized": "9.22.3",

--- a/packages/optimise-ui/package.json
+++ b/packages/optimise-ui/package.json
@@ -34,7 +34,7 @@
         "react-event-timeline": "1.6.3",
         "react-helmet-async": "1.3.0",
         "react-markdown": "8.0.3",
-        "react-medium-image-zoom": "3.1.3",
+        "react-medium-image-zoom": "5.0.2",
         "react-redux": "8.0.2",
         "react-router-dom": "5.3.3",
         "react-virtualized": "9.22.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15634,10 +15634,10 @@ react-markdown@8.0.3:
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
 
-react-medium-image-zoom@3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/react-medium-image-zoom/-/react-medium-image-zoom-3.1.3.tgz#b1470abc5a342d65c23021c01bafa8c731821478"
-  integrity sha512-5CoU8whSCz5Xz2xNeGD34dDfZ6jaf/pybdfZh8HNUmA9mbXbLfj0n6bQWfEUwkq9lsNg1sEkyeIJq2tcvZY8bw==
+react-medium-image-zoom@5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/react-medium-image-zoom/-/react-medium-image-zoom-5.0.2.tgz#2ec051205e7bfc53759f8a3a1bfd1c594f96100c"
+  integrity sha512-DGdsNaixDgXnEFFpCV6YHJYG4VQOvzs3PHS3h+nfIV82GO0cWetXrBQFGA77DMGODe6DuBX2SQPqZAQVKpLdcw==
 
 react-onclickoutside@^6.12.0:
   version "6.12.2"


### PR DESCRIPTION
**Information on the branch**
This branch merged the branch of react-medium-image-zoom-5.x for updating dependency, but **the version of "react-medium-image-zoom" keeps unchanged, i.e., version "3.1.3"**, because the latest version 5.0.2 caused a compile error when building optimise-electron.
 

**Test plan (required)**

All test are passed

<!-- Make sure tests pass on both Travis and Circle CI. -->

**Code formatting**
None
<!-- See the simple style guide. -->

**Closing issues**

None
