### PR TITLE
fix: Patient table foreign key restructuring

### DIFF
--- a/packages/optimise-core/src/db/clinical_events.table.js
+++ b/packages/optimise-core/src/db/clinical_events.table.js
@@ -22,6 +22,12 @@ export default async (dbcon, version) => {
             });
             await tableCopyBack(TABLE_NAME);
             break;
+        case 16:
+            await dbcon().schema.table(TABLE_NAME, (table) => {
+                table.dropForeign('patient');
+                table.foreign('patient').references('id').inTable('PATIENTS').onDelete('CASCADE');
+            });
+            break;
         default:
             break;
     }

--- a/packages/optimise-core/src/db/medical_history.table.js
+++ b/packages/optimise-core/src/db/medical_history.table.js
@@ -23,6 +23,12 @@ export default async (dbcon, version) => {
             });
             await tableCopyBack(TABLE_NAME);
             break;
+        case 16:
+            await dbcon().schema.table(TABLE_NAME, (table) => {
+                table.dropForeign('patient');
+                table.foreign('patient').references('id').inTable('PATIENTS').onDelete('CASCADE');
+            });
+            break;
         default:
             break;
     }

--- a/packages/optimise-core/src/db/patient_demographic.table.js
+++ b/packages/optimise-core/src/db/patient_demographic.table.js
@@ -66,6 +66,12 @@ export default async (dbcon, version) => {
             await schema_v2(dbcon);
             await tableCopyBack(TABLE_NAME);
             break;
+        case 16:
+            await dbcon().schema.table(TABLE_NAME, (table) => {
+                table.dropForeign('patient');
+                table.foreign('patient').references('id').inTable('PATIENTS').onDelete('CASCADE');
+            });
+            break;
         default:
             break;
     }

--- a/packages/optimise-core/src/db/patient_diagnosis.table.js
+++ b/packages/optimise-core/src/db/patient_diagnosis.table.js
@@ -20,6 +20,12 @@ export default async (dbcon, version) => {
             });
             await tableCopyBack(TABLE_NAME);
             break;
+        case 16:
+            await dbcon().schema.table(TABLE_NAME, (table) => {
+                table.dropForeign('patient');
+                table.foreign('patient').references('id').inTable('PATIENTS').onDelete('CASCADE');
+            });
+            break;
         default:
             break;
     }

--- a/packages/optimise-core/src/db/patient_immunisation.table.js
+++ b/packages/optimise-core/src/db/patient_immunisation.table.js
@@ -20,6 +20,12 @@ export default async (dbcon, version) => {
             });
             await tableCopyBack(TABLE_NAME);
             break;
+        case 16:
+            await dbcon().schema.table(TABLE_NAME, (table) => {
+                table.dropForeign('patient');
+                table.foreign('patient').references('id').inTable('PATIENTS').onDelete('CASCADE');
+            });
+            break;
         default:
             break;
     }

--- a/packages/optimise-core/src/db/patient_pii.table.js
+++ b/packages/optimise-core/src/db/patient_pii.table.js
@@ -22,6 +22,12 @@ export default async (dbcon, version) => {
             });
             await tableCopyBack(TABLE_NAME);
             break;
+        case 16:
+            await dbcon().schema.table(TABLE_NAME, (table) => {
+                table.dropForeign('patient');
+                table.foreign('patient').references('id').inTable('PATIENTS').onDelete('CASCADE');
+            });
+            break;
         default:
             break;
     }

--- a/packages/optimise-core/src/db/patient_pregnancy.table.js
+++ b/packages/optimise-core/src/db/patient_pregnancy.table.js
@@ -22,6 +22,12 @@ export default async (dbcon, version) => {
             });
             await tableCopyBack(TABLE_NAME);
             break;
+        case 16:
+            await dbcon().schema.table(TABLE_NAME, (table) => {
+                table.dropForeign('patient');
+                table.foreign('patient').references('id').inTable('PATIENTS').onDelete('CASCADE');
+            });
+            break;
         default:
             break;
     }

--- a/packages/optimise-core/src/db/visits.table.js
+++ b/packages/optimise-core/src/db/visits.table.js
@@ -20,6 +20,12 @@ export default async (dbcon, version) => {
             });
             await tableCopyBack(TABLE_NAME);
             break;
+        case 16:
+            await dbcon().schema.table(TABLE_NAME, (table) => {
+                table.dropForeign('patient');
+                table.foreign('patient').references('id').inTable('PATIENTS').onDelete('CASCADE');
+            });
+            break;
         default:
             break;
     }

--- a/packages/optimise-core/src/utils/db-handler.js
+++ b/packages/optimise-core/src/utils/db-handler.js
@@ -41,6 +41,8 @@ export async function migrate() {
         if (CURRENT_VERSION < stepVersion)
             return Promise.reject(new Error('The existing database was created with a newer version of Optimise ! Please upgrade before using Optimise !'));
 
+        await dbcon().raw('PRAGMA foreign_keys = OFF');
+
         // For every table file launch the update for sequential version up
         while (stepVersion < CURRENT_VERSION) {
             stepVersion++;
@@ -54,6 +56,8 @@ export async function migrate() {
             }
         }
 
+        await dbcon().raw('PRAGMA foreign_keys = ON');
+
         // Finally set the CURRENT_VERSION to the current level
         await dbcon()('OPT_KV').where({
             key: 'CURRENT_VERSION'
@@ -61,6 +65,7 @@ export async function migrate() {
             value: `${stepVersion}`,
             updated_at: dbcon().fn.now()
         });
+
     }
 
     return dbcon;

--- a/packages/optimise-ui/src/components/scaffold/syncIndicator.jsx
+++ b/packages/optimise-ui/src/components/scaffold/syncIndicator.jsx
@@ -39,7 +39,7 @@ class SyncIndicator extends Component {
     _updateStatus() {
 
         const now = (new Date()).getTime();
-        const { syncInfo: { config, status: { syncing, error, status, adminPass } }, loggedIn } = this.props;
+        const { syncInfo: { config, status: { syncing, error, status } }, loggedIn } = this.props;
         const { lastCall, triggered } = this.state;
         let state = this.state;
 


### PR DESCRIPTION
This is linked to the content date issue #1905 which did not account for foreign keys being rewired by `renameTable` in `knex`